### PR TITLE
Define primary and secondary color constants

### DIFF
--- a/app/GameScreen.tsx
+++ b/app/GameScreen.tsx
@@ -4,6 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from "expo-linear-gradient";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { LayoutChangeEvent, PixelRatio, Text, TouchableOpacity, View } from "react-native";
+import { SECONDARY_COLOR } from "../src/styles/colors";
 import { SafeAreaView } from "react-native-safe-area-context";
 import Bird from "../src/components/Bird";
 import { BushesFull, Cloud, Skyline, Soil } from "../src/components/CloudAndSoil";
@@ -182,7 +183,7 @@ export default function GameScreen() {
   const skylineH = toPxLocal(30);
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: '#87ceeb' }}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: SECONDARY_COLOR }}>
       <LinearGradient
         colors={[
           'rgb(135, 206, 250)',

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,0 +1,2 @@
+export const PRIMARY_COLOR = '#B8860B';
+export const SECONDARY_COLOR = '#87CEEB';

--- a/src/styles/gameStyles.ts
+++ b/src/styles/gameStyles.ts
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native';
+import { PRIMARY_COLOR, SECONDARY_COLOR } from './colors';
 
 const styles = StyleSheet.create({
   // Shared container used by both menu and game screens
@@ -13,7 +14,7 @@ const styles = StyleSheet.create({
   },
   // Game screen overlay to get a sky-like background while retaining base layout
   gameContainer: {
-    backgroundColor: '#87CEEB',
+    backgroundColor: SECONDARY_COLOR,
   },
 
   // Menu screen styles
@@ -27,7 +28,7 @@ const styles = StyleSheet.create({
     textShadowRadius: 6,
   },
   button: {
-    backgroundColor: '#B8860B',
+    backgroundColor: PRIMARY_COLOR,
     paddingHorizontal: 40,
     paddingVertical: 15,
     borderRadius: 25,
@@ -53,7 +54,7 @@ const styles = StyleSheet.create({
   
   // pipe styles removed; Pipe.tsx fully styles itself now
   score: {
-    color: '#B8860B',
+    color: PRIMARY_COLOR,
     fontSize: 24,
     fontWeight: 'bold',
     letterSpacing: 0.75,


### PR DESCRIPTION
## Summary
- centralize color scheme with PRIMARY_COLOR and SECONDARY_COLOR constants
- apply shared colors to game styles and gameplay screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68abb59790d883218f4f8f2765f84cf6