### PR TITLE
Add Babel config for Expo

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};


### PR DESCRIPTION
## Summary
- add babel.config.js using babel-preset-expo

## Testing
- `npm run lint`
- `npm start` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0d3a4bcc83219affe91d377989b6