### PR TITLE
chore: configure module path aliases

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,5 +6,12 @@ module.exports = defineConfig([
   expoConfig,
   {
     ignores: ['dist/*'],
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
   },
 ]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,17 @@
     "jsx": "react-jsx",
     "strict": true,
     "noImplicitAny": false,
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["*"],
+      "@core/*": ["src/core/*"],
+      "@classic/*": ["src/renderers/classic/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@state/*": ["src/state/*"],
+      "@utils/*": ["src/utils/*"],
+      "@types/*": ["src/types/*"],
+      "@ui/*": ["src/ui/*"],
+      "@assets/*": ["assets/*"]
     },
     "types": ["nativewind/types"]
   },


### PR DESCRIPTION
## Summary
- add baseUrl and structured path aliases in tsconfig
- configure ESLint to resolve TypeScript paths

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b61c197ee883218896c8be3adaa572