### PR TITLE
Configure Babel module resolver with path aliases

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,25 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['nativewind/babel'],
+    plugins: [
+      'nativewind/babel',
+      [
+        'module-resolver',
+        {
+          root: ['./'],
+          extensions: ['.ts', '.tsx', '.js', '.json'],
+          alias: {
+            '@core': './src/core',
+            '@classic': './src/renderers/classic',
+            '@hooks': './src/hooks',
+            '@state': './src/state',
+            '@utils': './src/utils',
+            '@types': './src/types',
+            '@ui': './src/ui',
+            '@assets': './assets',
+          },
+        },
+      ],
+    ],
   };
-}
+};

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
+    "babel-plugin-module-resolver": "^5.0.0",
     "typescript": "~5.8.3"
   },
   "private": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,15 @@
     "strict": true,
     "noImplicitAny": false,
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@core/*": ["./src/core/*"],
+      "@classic/*": ["./src/renderers/classic/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@state/*": ["./src/state/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@types/*": ["./src/types/*"],
+      "@ui/*": ["./src/ui/*"],
+      "@assets/*": ["./assets/*"]
     },
     "types": ["nativewind/types"]
   },


### PR DESCRIPTION
## Summary
- add module-resolver plugin to Babel config for simplified import aliases
- map TypeScript path aliases for core, hooks, state, utils and more
- declare babel-plugin-module-resolver dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b61db385b88321b6dd3ec40ab12f22