### PR TITLE
Render pipe images with cap

### DIFF
--- a/src/features/game/SkiaRenderer.tsx
+++ b/src/features/game/SkiaRenderer.tsx
@@ -1,0 +1,311 @@
+import { Canvas, Rect, LinearGradient, useImage, Image as SkImage, RadialGradient } from "@shopify/react-native-skia";
+import { useWindowDimensions } from "react-native";
+import {useMemo, useState, useCallback} from "react";
+import type { Bird } from "../../engine/types";
+import { CONFIG } from "../../engine/settings";
+import { useTicker } from "../../hooks/useTicker";
+
+function AnimatedBird({ width: _width, height: _height, groundHeight: _groundHeight, birdImg, bird }: { width: number; height: number; groundHeight: number; birdImg: ReturnType<typeof useImage>; bird: Bird }) {
+  if (!birdImg) return null;
+
+  const diameter = Math.max(1, Math.round(bird.r * 2));
+  const drawW = diameter;
+  const drawH = diameter;
+
+  return (
+    <SkImage
+      image={birdImg}
+      x={bird.pos.x - drawW / 2}
+      y={bird.pos.y - drawH / 2}
+      width={drawW}
+      height={drawH}
+    />
+  );
+}
+
+function AnimatedSky({ width, height, groundHeight, sunImg, elapsed }: { width: number; height: number; groundHeight: number; sunImg: ReturnType<typeof useImage>; elapsed: number }) {
+
+  const start = { x: 0, y: 0 } as const;
+  const end = { x: 0, y: height + height * 0.02 * Math.sin((2 * Math.PI * elapsed) / 30) } as const;
+  const sunRadius = height * (0.18 + 0.05 * Math.sin((2 * Math.PI * elapsed) / 10));
+  const sunCenter = {
+    x: width * 0.5,
+    y: height - groundHeight - height * 0.05
+  } as const;
+  const skyShift = 0.02 * Math.sin((2 * Math.PI * elapsed) / 30);
+
+  return (
+    <>
+      <Rect x={0} y={0} width={width} height={height}>
+        <LinearGradient
+          start={start}
+          end={end}
+          colors={["#3a1c71", "#ff5f6d", "#ffc371", "#fffacd"]}
+          positions={[0, Math.min(0.48, 0.33 + skyShift * 0.3), Math.min(0.8, 0.66 + skyShift * 0.6), 1]}
+        />
+      </Rect>
+      <Rect x={0} y={0} width={width} height={height} blendMode="plus">
+        <RadialGradient
+          c={sunCenter}
+          r={height * 0.28}
+          colors={["rgba(255,205,92,0.18)", "rgba(255,205,92,0.015)"]}
+          positions={[0, 1]}
+        />
+      </Rect>
+      <Rect x={0} y={0} width={width} height={height} blendMode="plus">
+        <RadialGradient
+          c={sunCenter}
+          r={sunRadius}
+          colors={["rgba(255,205,92,0.45)", "rgba(255,205,92,0.05)"]}
+          positions={[0, 1]}
+        />
+      </Rect>
+      {sunImg && (() => {
+        const sunW = width * 0.6;
+        const sunH = Math.round(sunImg.height() * (sunW / sunImg.width()));
+        return (
+          <SkImage
+            image={sunImg}
+            x={sunCenter.x - sunW / 2}
+            y={sunCenter.y - sunH / 2}
+            width={sunW}
+            height={sunH}
+          />
+        );
+      })()}
+    </>
+  );
+}
+
+export default function SkiaRenderer({ bird }: { bird: Bird }) {
+  const { width, height } = useWindowDimensions();
+  const groundImg = useImage(require('@assets/images/ground.png'));
+  const sunImg = useImage(require('@assets/images/sun.png'));
+  const cityBackgroundImg = useImage(require('@assets/images/citybgbackround.png'));
+  const cityForegroundImg = useImage(require('@assets/images/citybg.png'));
+  const pipeBodyImg = useImage(require('@assets/images/pipebody.png'));
+  const pipeCapImg = useImage(require('@assets/images/pipecap.png'));
+  const bushImg = useImage(require('@assets/images/bushes.png'));
+  const birdImg = useImage(require('@assets/images/birdmain.png'));
+
+
+  const groundTop = CONFIG.screen.floorY;
+  const groundThickness = Math.max(0, height - groundTop);
+  const groundHeight = useMemo(() => {
+    if (!groundImg) return groundThickness;
+    return Math.round(groundImg.height() * (width / groundImg.width()));
+  }, [groundImg, width]);
+
+  const [skyElapsed, setSkyElapsed] = useState(0);
+
+  const cityBackgroundHeight = useMemo(() => {
+    if (!cityBackgroundImg) return 0;
+    return Math.round(cityBackgroundImg.height() * (width / cityBackgroundImg.width()));
+  }, [cityBackgroundImg, width]);
+
+  const cityForegroundHeight = useMemo(() => {
+    if (!cityForegroundImg) return 0;
+    return Math.round(cityForegroundImg.height() * (width / cityForegroundImg.width()));
+  }, [cityForegroundImg, width]);
+
+  const defaultPipeWidth = useMemo(() => {
+    return Math.round(width * 0.1);
+  }, [width]);
+
+  const defaultPipeBodyHeight = useMemo(() => {
+    if (!pipeBodyImg) return 0;
+    return Math.round(pipeBodyImg.height() * (defaultPipeWidth / pipeBodyImg.width()));
+  }, [pipeBodyImg, defaultPipeWidth]);
+
+  const bushHeight = useMemo(() => {
+    if (!bushImg) return 0;
+    return Math.round(bushImg.height() * (width / bushImg.width()));
+  }, [bushImg, width]);
+
+  const bushImgWidth = useMemo(() => {
+    return width;
+  }, [width]);
+
+  const baseSpeed = useMemo(() => {
+    return width * 0.03;
+  }, [width]);
+
+  const speedForDepth = (z: number) => baseSpeed * (1 / (1 + z));
+
+  const bushSpeed = useMemo(() => {
+    return speedForDepth(1);
+  }, [baseSpeed]);
+
+  const bushOverlap = useMemo(() => {
+    return Math.round(width * 0.05);
+  }, [width]);
+
+  const [bushOffset, setBushOffset] = useState(0);
+
+  const tickBushes = useCallback((dt: number) => {
+    setBushOffset(prev => {
+      let next = prev - bushSpeed * dt;
+      const tileSpan = bushImgWidth - bushOverlap;
+      if (next <= -tileSpan) next += tileSpan;
+      return next;
+    });
+  }, [bushSpeed, bushImgWidth, bushOverlap]);
+
+  const cityBgSpeed = useMemo(() => {
+    return speedForDepth(3);
+  }, [baseSpeed]);
+
+  const cityFgSpeed = useMemo(() => {
+    return speedForDepth(2);
+  }, [baseSpeed]);
+
+  const [cityBgOffset, setCityBgOffset] = useState(0);
+  const [cityFgOffset, setCityFgOffset] = useState(0);
+
+  const tickCityBg = useCallback((dt: number) => {
+    if (!cityBackgroundImg) return;
+    setCityBgOffset(prev => {
+      let next = prev - cityBgSpeed * dt;
+      if (next <= -width) next += width;
+      return next;
+    });
+  }, [cityBackgroundImg, cityBgSpeed, width]);
+
+  const tickCityFg = useCallback((dt: number) => {
+    if (!cityForegroundImg) return;
+    setCityFgOffset(prev => {
+      let next = prev - cityFgSpeed * dt;
+      if (next <= -width) next += width;
+      return next;
+    });
+  }, [cityForegroundImg, cityFgSpeed, width]);
+
+  useTicker((dt) => {
+    tickBushes(dt);
+    tickCityBg(dt);
+    tickCityFg(dt);
+    setSkyElapsed((e) => e + dt);
+  });
+
+  if(!groundImg) return null;
+
+  const pipeCreator = useCallback(({ x, topY, width: pipeW, bodyHeight }: { x: number; topY: number; width: number; bodyHeight: number }) => {
+    if (!pipeBodyImg || !pipeCapImg) return null;
+    const capHeight = Math.round(pipeCapImg.height() * (pipeW / pipeCapImg.width()));
+    return (
+      <>
+        {/* Pipe body */}
+        <SkImage
+          image={pipeBodyImg}
+          x={x}
+          y={topY}
+          width={pipeW}
+          height={bodyHeight}
+        />
+        {/* Pipe cap above body */}
+        <SkImage
+          image={pipeCapImg}
+          x={x}
+          y={topY - capHeight}
+          width={pipeW}
+          height={capHeight}
+        />
+      </>
+    );
+  }, [pipeBodyImg, pipeCapImg]);
+
+  // groundTop already computed above
+
+  return (
+    <Canvas style={{ width, height }} pointerEvents="none">
+      <AnimatedSky width={width} height={height} groundHeight={groundThickness} sunImg={sunImg} elapsed={skyElapsed} />
+      
+      <Rect x={0} y={groundTop - Math.min(160, height * 0.2)} width={width} height={Math.min(160, height * 0.2)} blendMode="srcOver">
+        <LinearGradient
+          start={{ x: 0, y: groundTop - Math.min(160, height * 0.2) }}
+          end={{ x: 0, y: groundTop }}
+          colors={["rgba(255,140,105,0.08)", "rgba(255,140,105,0)"]}
+          positions={[0, 1]}
+        />
+      </Rect>
+
+      {cityBackgroundImg && (
+        <>
+          <SkImage 
+            image={cityBackgroundImg} 
+            x={cityBgOffset} 
+            y={groundTop - cityBackgroundHeight }
+            width={width} 
+            height={cityBackgroundHeight} 
+          />
+          <SkImage 
+            image={cityBackgroundImg} 
+            x={cityBgOffset + width} 
+            y={groundTop - cityBackgroundHeight } 
+            width={width} 
+            height={cityBackgroundHeight} 
+          />
+        </>
+      )}
+      {cityForegroundImg && (
+        <>
+          <SkImage 
+            image={cityForegroundImg} 
+            x={cityFgOffset} 
+            y={groundTop - cityForegroundHeight}
+            width={width} 
+            height={cityForegroundHeight} 
+          />
+          <SkImage 
+            image={cityForegroundImg} 
+            x={cityFgOffset + width} 
+            y={groundTop - cityForegroundHeight}
+            width={width} 
+            height={cityForegroundHeight} 
+          />
+        </>
+      )}
+      {bushImg && (
+        <>
+          <SkImage 
+            image={bushImg} 
+            x={bushOffset} 
+            y={groundTop - bushHeight} 
+            width={bushImgWidth} 
+            height={bushHeight}
+          />
+          <SkImage 
+            image={bushImg} 
+            x={bushOffset + bushImgWidth - bushOverlap} 
+            y={groundTop - bushHeight} 
+            width={bushImgWidth} 
+            height={bushHeight}
+          />
+        </>
+      )}
+
+      {pipeCreator({ x: width * 0.2, topY: groundTop - defaultPipeBodyHeight + 25, width: defaultPipeWidth, bodyHeight: defaultPipeBodyHeight })}
+
+      <SkImage 
+        image={groundImg} 
+        x={0} 
+        y={groundTop} 
+        width={width} 
+        height={groundHeight} 
+      />
+
+      <Rect x={0} y={height - Math.min(24, groundThickness * 0.35)} width={width} height={Math.min(24, groundThickness * 0.35)}>
+        <LinearGradient
+          start={{ x: 0, y: height - Math.min(24, groundThickness * 0.35) }}
+          end={{ x: 0, y: height }}
+          colors={["rgba(0,0,0,0)", "rgba(0,0,0,0.18)"]}
+          positions={[0, 1]}
+        />
+      </Rect>
+
+      {birdImg && (
+        <AnimatedBird width={width} height={height} groundHeight={groundHeight} birdImg={birdImg} bird={bird} />
+      )}
+    </Canvas>
+  );
+}


### PR DESCRIPTION
Add `pipeCreator` to `SkiaRenderer.tsx` to render pipes by composing cap and body images, decoupling rendering from game logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-811a55c0-973f-4de9-b989-fd1e794f5f8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-811a55c0-973f-4de9-b989-fd1e794f5f8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

