### PR TITLE
Set pipe and cap starting heights

### DIFF
--- a/src/engine/spawning.ts
+++ b/src/engine/spawning.ts
@@ -1,6 +1,40 @@
-//pipe spawning logic and pipe movement logic will be used to spawn the pipes and move them. and also pipe recycling logic will be used to recycle the pipes when they are off the screen.
-//pipes will be spawned in three different ways 
-//single top pipe
-//single bottom pipe
-//pipe pair
-//pipe pair with a gap between them
+import type { Pipe } from "./types";
+import { CONFIG } from "./settings";
+
+// Pipe spawning helpers
+// - Bottom pipe anchors its body on the ground top (floorY)
+// - Cap is rendered by the sprite component directly above the body
+
+/**
+ * Create a single bottom pipe whose body sits on the ground.
+ * The returned pipe's pos.y is the ground-top, matching the renderer's
+ * expectation that for orientation "bottom" the body extends upward from y.
+ */
+export function createBottomPipe(x: number, bodyHeight: number = CONFIG.pipe.height): Pipe {
+  return {
+    pos: { x, y: CONFIG.screen.floorY },
+    size: { width: CONFIG.pipe.width, height: bodyHeight },
+    orientation: "bottom",
+  };
+}
+
+/**
+ * Create a single top pipe whose body hangs down from the given y (default: 0)
+ * For orientation "top", the renderer draws the body downward from y.
+ */
+export function createTopPipe(x: number, y: number = 0, bodyHeight: number = CONFIG.pipe.height): Pipe {
+  return {
+    pos: { x, y },
+    size: { width: CONFIG.pipe.width, height: bodyHeight },
+    orientation: "top",
+  };
+}
+
+/**
+ * Compute the Y anchor for a pipe based on its orientation.
+ * - bottom => ground top (floorY)
+ * - top => 0 (screen top)
+ */
+export function getPipeStartY(orientation: Pipe["orientation"]): number {
+  return orientation === "bottom" ? CONFIG.screen.floorY : 0;
+}

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -5,6 +5,13 @@ export interface Bird {
   r: number;
 }
 
+// Renderable pipe entity used across physics, spawning, and rendering
+export interface Pipe {
+  pos: { x: number; y: number }; // Anchor Y: top for "top" pipes, ground-top for "bottom" pipes
+  size: { width: number; height: number }; // Body dimensions (cap thickness handled by renderer)
+  orientation: "top" | "bottom";
+}
+
 export type PipeRects = {
 body: { x: number; y: number; width: number; height: number };
 cap: { x: number; y: number; width: number; height: number };

--- a/src/features/game/PipeSprite.tsx
+++ b/src/features/game/PipeSprite.tsx
@@ -37,7 +37,10 @@ export default function PipeSprite({
   const capW = width + capOverhang * 2;
   const capH = capThickness;
   const capX = x - capOverhang;
-  const capY = orientation === "bottom" ? bodyY - capH : y + height;
+  // Place the cap at the top edge of the pipe body
+  // bottom: cap aligns with the body's top (at bodyY)
+  // top: cap aligns with the body's bottom (at y + height)
+  const capY = orientation === "bottom" ? bodyY : y + height;
 
   return (
     <Group>


### PR DESCRIPTION
Adjust pipe positioning to anchor bottom pipes to the ground and place caps directly on top of pipe bodies.

---
<a href="https://cursor.com/background-agent?bcId=bc-018f284f-ad0b-4752-b60a-dc9c257a810b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-018f284f-ad0b-4752-b60a-dc9c257a810b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

